### PR TITLE
🔒 [security fix] Implement URL validation for open-url IPC and external links

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,7 @@
     "react-start": "webpack serve --mode development",
     "build": "tauri build",
     "electron": "electron .",
-    "electron-pack": "electron-builder build",
-
+    "electron-pack": "electron-builder build"
   },
   "keywords": [
     "personal-assistant",

--- a/public/electron.js
+++ b/public/electron.js
@@ -60,7 +60,9 @@ function createWindow() {
 
   // Handle external links
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    if (isValidExternalUrl(url)) {
+      shell.openExternal(url);
+    }
     return { action: 'deny' };
   });
 
@@ -267,7 +269,9 @@ function initializeBackgroundServices() {
 app.on('web-contents-created', (event, contents) => {
   contents.on('new-window', (event, url) => {
     event.preventDefault();
-    shell.openExternal(url);
+    if (isValidExternalUrl(url)) {
+      shell.openExternal(url);
+    }
   });
 });
 
@@ -315,6 +319,19 @@ const validatePath = (userInputPath) => {
   }
 
   return resolvedPath;
+};
+
+/**
+ * Validates external URLs before opening them.
+ * Only allows http: and https: protocols to prevent RCE and other attacks.
+ */
+const isValidExternalUrl = (url) => {
+  try {
+    const parsedUrl = new URL(url);
+    return ['http:', 'https:'].includes(parsedUrl.protocol);
+  } catch (error) {
+    return false;
+  }
 };
 
 const loadData = () => {
@@ -813,6 +830,9 @@ ipcMain.handle('get-system-info', async () => {
 
 ipcMain.handle('open-url', async (event, url) => {
   try {
+    if (!isValidExternalUrl(url)) {
+      throw new Error('Invalid URL protocol');
+    }
     await shell.openExternal(url);
     return { success: true, url };
   } catch (error) {
@@ -922,6 +942,9 @@ ipcMain.handle('system-get-usage', async () => {
 // Handle external links
 ipcMain.handle('open-external', async (event, url) => {
   try {
+    if (!isValidExternalUrl(url)) {
+      throw new Error('Invalid URL protocol');
+    }
     await shell.openExternal(url);
     return { success: true };
   } catch (error) {

--- a/tests/verify_url_security.mjs
+++ b/tests/verify_url_security.mjs
@@ -1,0 +1,52 @@
+/**
+ * Standalone verification script for URL validation logic.
+ * Bypasses Jest to ensure reliability in unstable environments.
+ */
+
+const isValidExternalUrl = (url) => {
+  try {
+    const parsedUrl = new URL(url);
+    return ['http:', 'https:'].includes(parsedUrl.protocol);
+  } catch (error) {
+    return false;
+  }
+};
+
+const tests = [
+  { url: 'https://google.com', expected: true, desc: 'Valid HTTPS URL' },
+  { url: 'http://example.com', expected: true, desc: 'Valid HTTP URL' },
+  { url: 'ftp://files.com', expected: false, desc: 'Invalid FTP protocol' },
+  { url: 'file:///etc/passwd', expected: false, desc: 'Malicious file:// protocol' },
+  { url: 'javascript:alert(1)', expected: false, desc: 'Malicious javascript: protocol' },
+  { url: 'data:text/html,<html>', expected: false, desc: 'Invalid data: protocol' },
+  { url: 'not-a-url', expected: false, desc: 'Invalid URL string' },
+  { url: '', expected: false, desc: 'Empty string' },
+  { url: 'https://user:pass@google.com', expected: true, desc: 'Valid HTTPS with credentials' },
+  { url: 'https://google.com:8080/path?q=1#hash', expected: true, desc: 'Valid HTTPS with port and path' }
+];
+
+let passed = 0;
+let failed = 0;
+
+console.log('🧪 Running URL Security Validation Tests...\n');
+
+tests.forEach(({ url, expected, desc }) => {
+  const result = isValidExternalUrl(url);
+  if (result === expected) {
+    console.log(`✅ PASS: ${desc} (${url})`);
+    passed++;
+  } else {
+    console.error(`❌ FAIL: ${desc}`);
+    console.error(`   URL: ${url}`);
+    console.error(`   Expected: ${expected}, Got: ${result}`);
+    failed++;
+  }
+});
+
+console.log(`\n📊 Summary: ${passed} passed, ${failed} failed`);
+
+if (failed > 0) {
+  process.exit(1);
+} else {
+  console.log('✨ All tests passed successfully!');
+}


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
The application previously passed user-provided URLs directly to `shell.openExternal` without validation. This allowed an attacker to use malicious protocols (e.g., `file:`, `javascript:`, or OS-specific handlers) to execute arbitrary code or access sensitive local files.

### ⚠️ Risk: The potential impact if left unfixed
An attacker could exploit this to achieve Remote Code Execution (RCE) on the user's machine, steal sensitive data, or perform unauthorized system actions.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix introduces a strict white-list for external URLs. A new utility function `isValidExternalUrl` uses the built-in `URL` constructor to parse incoming strings and ensures that only `http:` and `https:` protocols are permitted. This validation is now enforced across all entry points that call `shell.openExternal`, including IPC handlers and window navigation events. Additionally, a standalone verification script has been added to ensure the validation logic remains robust.

---
*PR created automatically by Jules for task [17426693376078315614](https://jules.google.com/task/17426693376078315614) started by @kimberlyvargas1723-cmd*

## Summary by Sourcery

Enforce strict validation of external URLs before opening them to mitigate protocol-based security vulnerabilities.

New Features:
- Add centralized URL validation helper that only permits http and https protocols for external links.
- Introduce a standalone Node-based verification script to exercise URL validation logic outside the main test framework.

Bug Fixes:
- Guard all shell.openExternal entry points, including window open handlers and IPC endpoints, with URL validation to block dangerous protocols and malformed URLs.

Build:
- Clean up the npm scripts definition in package.json by removing an unnecessary trailing comma.

Tests:
- Add a standalone URL security verification script that runs a suite of positive and negative cases against the URL validator.