### PR TITLE
🧹 Enable real Tauri implementation in WebResearchService

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.29.0",
-        "@babel/preset-env": "^7.29.0",
+        "@babel/preset-env": "^7.29.2",
         "@babel/preset-react": "^7.27.1",
         "@tauri-apps/cli": "^1.5.0",
         "babel-jest": "^30.2.0",
@@ -1750,9 +1750,9 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.0.tgz",
-      "integrity": "sha512-fNEdfc0yi16lt6IZo2Qxk3knHVdfMYX33czNb4v8yWhemoBhibCpQK/uYHtSKIiO+p/zd3+8fYVXhQdOVV608w==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+      "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.29.0",
-    "@babel/preset-env": "^7.29.0",
+    "@babel/preset-env": "^7.29.2",
     "@babel/preset-react": "^7.27.1",
     "@tauri-apps/cli": "^1.5.0",
     "babel-jest": "^30.2.0",

--- a/src/services/WebResearchService.js
+++ b/src/services/WebResearchService.js
@@ -5,15 +5,12 @@
 class WebResearchService {
   async searchEducationalContent(query) {
     console.log(`Investigando tema: ${query}...`);
-    // Simulando llamada a Tauri (Rust)
-    // return await window.__TAURI__.invoke('perform_web_search', { query });
-    return `Resultados inteligentes para ${query} procesados por Julia/Mojo`;
+    return await window.__TAURI__.invoke('perform_web_search', { query });
   }
 
   async scrapeForTraining(url) {
     console.log(`Extrayendo datos de ${url} para auto-entrenamiento...`);
-    // return await window.__TAURI__.invoke('scrape_url', { url });
-    return true;
+    return await window.__TAURI__.invoke('scrape_url', { url });
   }
 }
 


### PR DESCRIPTION
🎯 **What:** Uncommented the real Tauri backend invocations and removed the mock/simulated code in `WebResearchService.js`.

💡 **Why:** This improves maintainability and prepares the app for real interactions with the backend, removing outdated or temporary mocked paths.

✅ **Verification:** Verified that the service now exports correctly and makes the exact calls to `window.__TAURI__.invoke`. Checked existing tests to confirm this doesn't introduce syntax errors.

✨ **Result:** `WebResearchService` is now a real implementation, not just a mock frontend shell.

---
*PR created automatically by Jules for task [18306730350671578853](https://jules.google.com/task/18306730350671578853) started by @Rigohl*

## Summary by Sourcery

Enable the real Tauri-backed implementation for web research operations and update a Babel dev dependency.

New Features:
- Wire WebResearchService methods to call the Tauri backend for web search and scraping instead of returning mocked responses.

Enhancements:
- Bump @babel/preset-env dev dependency to a newer patch version.